### PR TITLE
Bugfix: query mirroring

### DIFF
--- a/src/hictkpy_file.cpp
+++ b/src/hictkpy_file.cpp
@@ -71,7 +71,7 @@ hictkpy::PixelSelector fetch(const hictk::File &f, std::string_view range1, std:
                  : hictk::GenomicInterval::parse_bed(f.chromosomes(), range2);
   bool mirror = false;
 
-  if (gi1 > gi2) {
+  if (gi1 > gi2 || (gi1.chrom() == gi2.chrom() && gi1.start() > gi2.start())) {
     mirror = true;
     std::swap(gi1, gi2);
   }

--- a/src/hictkpy_pixel_selector.cpp
+++ b/src/hictkpy_pixel_selector.cpp
@@ -206,7 +206,7 @@ nb::object PixelSelector::to_numpy() const {
   const auto col_offset = static_cast<std::int64_t>(coord2().bin1.id());
 
   return std::visit(
-      [&, num_rows, num_cols, mirror_matrix](const auto& s) {
+      [&, num_rows, num_cols, mirror_matrix, row_offset, col_offset](const auto& s) {
         if (int_pixels()) {
           using T = std::int32_t;
           return pixel_iterators_to_numpy(s->template begin<T>(), s->template end<T>(), num_rows,

--- a/src/hictkpy_pixel_selector.cpp
+++ b/src/hictkpy_pixel_selector.cpp
@@ -202,18 +202,19 @@ nb::object PixelSelector::to_numpy() const {
 
   const auto mirror_matrix = coord1().bin1.chrom() == coord2().bin1.chrom();
 
+  const auto row_offset = static_cast<std::int64_t>(coord1().bin1.id());
+  const auto col_offset = static_cast<std::int64_t>(coord2().bin1.id());
+
   return std::visit(
       [&, num_rows, num_cols, mirror_matrix](const auto& s) {
         if (int_pixels()) {
           using T = std::int32_t;
           return pixel_iterators_to_numpy(s->template begin<T>(), s->template end<T>(), num_rows,
-                                          num_cols, mirror_matrix, coord1().bin1.id(),
-                                          coord2().bin1.id());
+                                          num_cols, mirror_matrix, row_offset, col_offset);
         } else {
           using T = double;
           return pixel_iterators_to_numpy(s->template begin<T>(), s->template end<T>(), num_rows,
-                                          num_cols, mirror_matrix, coord1().bin1.id(),
-                                          coord2().bin1.id());
+                                          num_cols, mirror_matrix, row_offset, col_offset);
         }
       },
       selector);

--- a/src/include/hictkpy/common.hpp
+++ b/src/include/hictkpy/common.hpp
@@ -321,7 +321,10 @@ inline nb::object pixel_iterators_to_numpy(PixelIt first_pixel, PixelIt last_pix
       } else if (i2 - i1 > num_cols && i1 < num_cols && i2 < num_rows) {
         const auto i3 = static_cast<std::int64_t>(tp.bin2_id - row_offset);
         const auto i4 = static_cast<std::int64_t>(tp.bin1_id - col_offset);
-        m(i3, i4) = tp.count;
+
+        if (i3 >= 0 && i3 < num_rows && i4 >= 0 && i4 < num_cols) {
+          m(i3, i4) = tp.count;
+        }
       }
     }
   });

--- a/test/test_fetch_dense.py
+++ b/test/test_fetch_dense.py
@@ -42,6 +42,18 @@ class TestClass:
         m = f.fetch("chr2R\t10000000\t15000000", query_type="BED").to_numpy()
         assert m.shape == (50, 50)
 
+        m = f.fetch("chr2L:0-10,000,000", "chr2L:5,000,000-20,000,000").to_numpy()
+        assert m.shape == (100, 150)
+        assert m.sum() == 6_287_451
+
+        m = f.fetch("chr2L:0-10,000,000", "chr2L:10,000,000-20,000,000").to_numpy()
+        assert m.shape == (100, 100)
+        assert m.sum() == 761_223
+
+        m = f.fetch("chr2L:0-10,000,000", "chr2L:0-15,000,000").to_numpy()
+        assert m.shape == (100, 150)
+        assert m.sum() == 12_607_205
+
     def test_trans(self, file, resolution):
         f = hictkpy.File(file, resolution)
         m = f.fetch("chr2R:10,000,000-15,000,000", "chrX:0-10,000,000").to_numpy()

--- a/test/test_fetch_df.py
+++ b/test/test_fetch_df.py
@@ -48,6 +48,14 @@ class TestClass:
         df = f.fetch("chr2R\t10000000\t15000000", query_type="BED").to_df()
         assert len(df) == 1275
 
+        df = f.fetch("chr2L:0-10,000,000", "chr2L:10,000,000-20,000,000").to_df()
+        assert df["count"].sum() == 761_223
+        assert len(df) == 9_999
+
+        df = f.fetch("chr2L:0-10,000,000", "chr2L:0-15,000,000").to_df()
+        assert df["count"].sum() == 9_270_385
+        assert len(df) == 10_050
+
     def test_trans(self, file, resolution):
         f = hictkpy.File(file, resolution)
 

--- a/test/test_fetch_sparse.py
+++ b/test/test_fetch_sparse.py
@@ -44,6 +44,14 @@ class TestClass:
         m = f.fetch("chr2R\t10000000\t15000000", query_type="BED").to_coo()
         assert m.shape == (50, 50)
 
+        m = f.fetch("chr2L:0-10,000,000", "chr2L:10,000,000-20,000,000").to_coo()
+        assert m.shape == (100, 100)
+        assert m.sum() == 761_223
+
+        m = f.fetch("chr2L:0-10,000,000", "chr2L:0-15,000,000").to_coo()
+        assert m.shape == (100, 150)
+        assert m.sum() == 9_270_385
+
     def test_trans(self, file, resolution):
         f = hictkpy.File(file, resolution)
 


### PR DESCRIPTION
Fix two bugs that could sometimes be triggered when fetching subsets of cis matrices in dense matrix format.