### PR TITLE
Workaround macOS CI failure

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -80,6 +80,12 @@ jobs:
         key: conan-${{ steps.cache-key.outputs.conan-key }}
         path: ${{ env.CONAN_HOME }}
 
+    - name: Override default compilers (macOS)
+      if: matrix.platform == 'macos-latest'
+      run: |
+        echo 'CC=clang' >> $GITHUB_ENV
+        echo 'CXX=clang++' >> $GITHUB_ENV
+
     - name: Build and install
       run: pip install --verbose '.[test]'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,7 +96,8 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_ENVIRONMENT_MACOS: "CC=clang CXX=clang++"
+          CIBW_ENVIRONMENT: "PIP_VERBOSE=1"
+          CIBW_ENVIRONMENT_MACOS: "CC=clang CXX=clang++ MACOSX_DEPLOYMENT_TARGET=10.15"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19
@@ -104,7 +105,8 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_ENVIRONMENT_MACOS: "CC=clang CXX=clang++"
+          CIBW_ENVIRONMENT: "PIP_VERBOSE=1"
+          CIBW_ENVIRONMENT_MACOS: "CC=clang CXX=clang++ MACOSX_DEPLOYMENT_TARGET=10.15"
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,6 +96,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_ENVIRONMENT_MACOS: "CC=clang" "CXX=clang++"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19
@@ -103,6 +104,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_ENVIRONMENT_MACOS: "CC=clang" "CXX=clang++"
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,7 +96,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_ENVIRONMENT_MACOS: "CC=clang" "CXX=clang++"
+          CIBW_ENVIRONMENT_MACOS: "CC=clang CXX=clang++"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19
@@ -104,7 +104,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_ENVIRONMENT_MACOS: "CC=clang" "CXX=clang++"
+          CIBW_ENVIRONMENT_MACOS: "CC=clang CXX=clang++"
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,6 @@ test-skip = ["*universal2", "pp*"]
 before-build = [
   "rm -rf '{project}/build'",
 ]
-environment = { PIP_VERBOSE=1 }
-
-[tool.cibuildwheel.macos]
-environment = { MACOSX_DEPLOYMENT_TARGET=11 }
 
 [tool.ruff]
 extend-select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ before-build = [
 environment = { PIP_VERBOSE=1 }
 
 [tool.cibuildwheel.macos]
-environment = { MACOSX_DEPLOYMENT_TARGET=10.15 }
+environment = { MACOSX_DEPLOYMENT_TARGET=11 }
 
 [tool.ruff]
 extend-select = [


### PR DESCRIPTION
It turns out there were a couple of problems:
- On some (but not all!) macOS images, gcc and g++ were detected as default compilers. This caused `conan profile detect` to generate incomplete profiles
- Setting `MACOSX_DEPLOYMENT_TARGET` in the `pyproject.toml` was not working as expected, leading to errors when running `delocate`