### PR TITLE
Make pandas and scipy optional deps

### DIFF
--- a/.github/workflows/build-conan-deps.yml
+++ b/.github/workflows/build-conan-deps.yml
@@ -1,0 +1,456 @@
+# Copyright (C) 2024 Roberto Rossini <roberros@uio.no>
+# SPDX-License-Identifier: MIT
+
+name: Build dependencies with Conan
+
+on:
+  workflow_call:
+    outputs:
+      conan-key:
+        description: "Conan packages"
+        value: ${{ jobs.collect-outputs.outputs.conan-key }}
+      conan-home:
+        description: "Conan home folder"
+        value: ${{ jobs.collect-outputs.outputs.conan-home }}
+
+    inputs:
+      conan-version:
+        default: "2.8.*"
+        type: string
+        required: false
+        description: "Conan version to be installed with pip."
+      cppstd:
+        default: "17"
+        type: string
+        required: false
+        description: "Value to pass to compiler.cppstd."
+      os:
+        type: string
+        required: true
+        description: "OS used to build Conan deps."
+      arch:
+        type: string
+        required: true
+        description: "Architecture used to build deps."
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-deps-linux:
+    if: contains(inputs.os, 'linux')
+    name: Build dependencies with Conan (${{ inputs.os }})
+    runs-on: ubuntu-latest
+
+    env:
+      CONAN_HOME: "${{ github.workspace }}/.conan2"
+      IMAGE: quay.io/pypa/manylinux_2_28_${{ inputs.arch }}
+
+    outputs:
+      conan-key: ${{ steps.generate-cache-key.outputs.conan-key }}
+      conan-home: ${{ env.CONAN_HOME }}
+
+    steps:
+      - name: Checkout workflow
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: hictkpy-workflow
+
+      - name: Checkout conanfile.py
+        uses: actions/checkout@v4
+        with:
+          path: hictkpy-conanfile
+
+      - name: Stage input files
+        run: |
+          # This is required because sparse cloning does not seem to work reliably
+          mkdir -p .github/workflows/
+          mv hictkpy-workflow/.github/workflows/build-conan-deps.yml .github/workflows/
+          mv hictkpy-conanfile/conanfile.py .
+          rm -rf hictkpy-workflow hictkpy-conanfile
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Generate cache key
+        id: generate-cache-key
+        run: |
+          cat << 'EOF' | tee script.sh > /dev/null
+          #!usr/bin/env bash
+          set -u
+          set -e
+
+          hash="${{ hashFiles('.github/workflows/build-conan-deps.yml', 'conanfile.py') }}"
+
+          compiler="$(cc --version | head -n 1 | tr -c '[:alnum:]._-' '-' | sed 's/-\+/-/g' | sed 's/-$//')"
+
+          suffix="${{ inputs.os }}-${{ inputs.arch }}-$compiler-c++${{ inputs.cppstd }}-$hash"
+
+          echo "conan-key=conan-$suffix"
+          EOF
+
+          chmod 755 script.sh
+
+          docker run \
+            -v "$PWD/script.sh:/tmp/script.sh:ro" \
+            "$IMAGE" /tmp/script.sh | tee -a "$GITHUB_OUTPUT"
+
+      - name: Restore package cache
+        id: cache-conan
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: ${{ env.CONAN_HOME }}/p
+
+      - name: Clean Conan cache (pre-build)
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          cat << 'EOF' | tee script.sh > /dev/null
+          #!usr/bin/env bash
+          set -u
+          set -e
+
+          conan_version="$1"
+
+          PATH="/opt/python/cp312-cp312/bin:$PATH"
+          pip install "conan==$conan_version"
+          conan profile detect --force
+
+          conan cache clean "*" --build
+          conan cache clean "*" --download
+          conan cache clean "*" --source
+          conan remove --confirm "*"
+          EOF
+
+          chmod 755 script.sh
+
+          docker run \
+            -e "CONAN_HOME=$CONAN_HOME" \
+            -v "$PWD/script.sh:/tmp/script.sh:ro" \
+            -v "$CONAN_HOME:$CONAN_HOME" \
+            "$IMAGE" /tmp/script.sh '${{ inputs.conan-version }}'
+
+      - name: Install dependencies
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          cat << 'EOF' | tee script.sh > /dev/null
+          #!usr/bin/env bash
+          set -u
+          set -e
+
+          conan_version="$1"
+          cppstd="$2"
+
+          PATH="/opt/python/cp312-cp312/bin:$PATH"
+          pip install "conan==$conan_version"
+          conan profile detect --force
+
+          conan install /tmp/conanfile.py \
+             --update                     \
+             --build='missing'            \
+             -pr:b=default                \
+             -pr:h=default                \
+             -s build_type=Release        \
+             -s compiler.cppstd="$cppstd" \
+             --options='*/*:shared=False'
+          EOF
+
+          chmod 755 script.sh
+
+          docker run \
+            -e "CONAN_HOME=$CONAN_HOME" \
+            -v "$PWD/script.sh:/tmp/script.sh:ro" \
+            -v "$PWD/conanfile.py:/tmp/conanfile.py:ro" \
+            -v "$CONAN_HOME:$CONAN_HOME" \
+            "$IMAGE" /tmp/script.sh '${{ inputs.conan-version }}' '${{ inputs.cppstd }}'
+
+      - name: Clean Conan cache (post-build)
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          cat << 'EOF' | tee script.sh > /dev/null
+          #!usr/bin/env bash
+          set -u
+          set -e
+
+          conan_version="$1"
+
+          PATH="/opt/python/cp312-cp312/bin:$PATH"
+          pip install "conan==$conan_version"
+          conan profile detect --force
+
+          conan cache clean "*" --build
+          conan cache clean "*" --download
+          conan cache clean "*" --source
+          EOF
+
+          chmod 755 script.sh
+
+          docker run \
+            -e "CONAN_HOME=$CONAN_HOME" \
+            -v "$PWD/script.sh:/tmp/script.sh:ro" \
+            -v "$CONAN_HOME:$CONAN_HOME" \
+            "$IMAGE" /tmp/script.sh '${{ inputs.conan-version }}'
+
+      - name: Save Conan cache
+        uses: actions/cache/save@v4
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: ${{ env.CONAN_HOME }}/p
+        env:
+          ZSTD_CLEVEL: 19
+
+  build-deps-macos:
+    if: startsWith(inputs.os, 'macos')
+    name: Build dependencies with Conan (${{ inputs.os }})
+    runs-on: ${{ inputs.os }}
+
+    env:
+      CONAN_HOME: "${{ github.workspace }}/.conan2"
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+
+    outputs:
+      conan-key: ${{ steps.generate-cache-key.outputs.conan-key }}
+      conan-home: ${{ env.CONAN_HOME }}
+
+    steps:
+      - name: Checkout workflow
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: hictkpy-workflow
+
+      - name: Checkout conanfile.py
+        uses: actions/checkout@v4
+        with:
+          path: hictkpy-conanfile
+
+      - name: Stage input files
+        run: |
+          # This is required because sparse cloning does not seem to work reliably
+          mkdir -p .github/workflows/
+          mv hictkpy-workflow/.github/workflows/build-conan-deps.yml .github/workflows/
+          mv hictkpy-conanfile/conanfile.py .
+          rm -rf hictkpy-workflow hictkpy-conanfile
+
+      - name: Generate cache key
+        id: generate-cache-key
+        run: |
+          set -u
+          set -e
+
+          hash="${{ hashFiles('.github/workflows/build-conan-deps.yml', 'conanfile.py') }}"
+
+          compiler="$(cc --version | head -n 1 | tr -c '[:alnum:]._-' '-' | sed 's/-\+/-/g' | sed 's/-$//')"
+
+          suffix="${{ inputs.os }}-${{ inputs.arch }}-$compiler-c++${{ inputs.cppstd }}-$hash"
+
+          echo "conan-key=conan-$suffix" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Restore package cache
+        id: cache-conan
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: ${{ env.CONAN_HOME }}/p
+
+      - uses: actions/setup-python@v5
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Update build deps
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: pip install "conan==${{ inputs.conan-version }}"
+
+      - name: Configure Conan
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: conan profile detect --force
+
+      - name: Clean Conan cache (pre-build)
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          conan cache clean "*" --build
+          conan cache clean "*" --download
+          conan cache clean "*" --source
+          conan remove --confirm "*"
+
+      - name: Install dependencies
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          conan install conanfile.py                  \
+             --update                                 \
+             --build='missing'                        \
+             -pr:b=default                            \
+             -pr:h=default                            \
+             -s build_type=Release                    \
+             -s compiler.cppstd=${{ inputs.cppstd }}  \
+             --options='*/*:shared=False'
+
+      - name: Clean Conan cache (post-build)
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          conan cache clean "*" --build
+          conan cache clean "*" --download
+          conan cache clean "*" --source
+
+      - name: Save Conan cache
+        uses: actions/cache/save@v4
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: ${{ env.CONAN_HOME }}/p
+        env:
+          ZSTD_CLEVEL: 19
+
+  build-deps-windows:
+    if: startsWith(inputs.os, 'windows')
+    name: Build dependencies with Conan (${{ inputs.os }})
+    runs-on: ${{ inputs.os }}
+
+    env:
+      CONAN_HOME: "${{ github.workspace }}\\.conan2"
+
+    outputs:
+      conan-key: ${{ steps.generate-cache-key.outputs.conan-key }}
+      conan-home: ${{ env.CONAN_HOME }}
+
+    steps:
+      - name: Checkout workflow
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: hictkpy-workflow
+
+      - name: Checkout conanfile.py
+        uses: actions/checkout@v4
+        with:
+          path: hictkpy-conanfile
+
+      - name: Stage input files
+        run: |
+          # This is required because sparse cloning does not seem to work reliably
+          mkdir -p .github/workflows/
+          mv hictkpy-workflow/.github/workflows/build-conan-deps.yml .github/workflows/
+          mv hictkpy-conanfile/conanfile.py .
+          rm -rf hictkpy-workflow hictkpy-conanfile
+
+      - name: Add devtools to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Generate cache key
+        id: generate-cache-key
+        run: |
+          set -u
+          set -e
+
+          hash="${{ hashFiles('.github/workflows/build-conan-deps.yml', 'conanfile.py') }}"
+
+          cl.exe 1> /dev/null 2> version.txt
+          compiler="msvc-$(head -n 1 version.txt | grep -o '[[:digit:].]\+' | head -n 1)"
+
+          suffix="${{ inputs.os }}-${{ inputs.arch }}-$compiler-c++${{ inputs.cppstd }}-$hash"
+
+          echo "conan-key=conan-$suffix" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Restore package cache
+        id: cache-conan
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: ${{ env.CONAN_HOME }}\p
+
+      - uses: actions/setup-python@v5
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Update build deps
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: pip install "conan==${{ inputs.conan-version }}"
+
+      - name: Configure Conan
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          conan profile detect --force
+          conan_profile="$(conan profile path default)"
+
+          sed -i 's/compiler\.cppstd=.*/compiler.cppstd=${{ inputs.cppstd }}/' "$conan_profile"
+
+      - name: Clean Conan cache (pre-build)
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          conan cache clean "*" --build
+          conan cache clean "*" --download
+          conan cache clean "*" --source
+          conan remove --confirm "*"
+
+      - name: Install dependencies
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          conan install conanfile.py                  \
+             --update                                 \
+             --build='missing'                        \
+             -pr:b=default                            \
+             -pr:h=default                            \
+             -s build_type=Release                    \
+             -s compiler.runtime_type=Release         \
+             -s compiler.cppstd=${{ inputs.cppstd }}  \
+             --options='*/*:shared=False'
+
+      - name: Clean Conan cache (post-build)
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        run: |
+          conan cache clean "*" --build
+          conan cache clean "*" --download
+          conan cache clean "*" --source
+
+      - name: Save Conan cache
+        uses: actions/cache/save@v4
+        if: steps.cache-conan.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.generate-cache-key.outputs.conan-key }}
+          path: ${{ env.CONAN_HOME }}\p
+        env:
+          ZSTD_CLEVEL: 19
+
+  collect-outputs:
+    name: Collect output
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - build-deps-macos
+      - build-deps-linux
+      - build-deps-windows
+
+    outputs:
+      conan-key: ${{ steps.collect-cache-key.outputs.conan-key }}
+      conan-home: ${{ steps.collect-cache-key.outputs.conan-home }}
+
+    steps:
+      - name: Collect job outputs
+        id: collect-cache-key
+        run: |
+          if [ "${{ needs.build-deps-linux.result }}" == 'success' ]; then
+            echo "conan-key=${{ needs.build-deps-linux.outputs.conan-key }}" | tee -a "$GITHUB_OUTPUT"
+            echo "conan-home=${{ needs.build-deps-linux.outputs.conan-home }}" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ needs.build-deps-macos.result }}" == 'success' ]; then
+            echo "conan-key=${{ needs.build-deps-macos.outputs.conan-key }}" | tee -a "$GITHUB_OUTPUT"
+            echo "conan-home=${{ needs.build-deps-macos.outputs.conan-home }}" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ needs.build-deps-windows.result }}" == 'success' ]; then
+            echo "conan-key=${{ needs.build-deps-windows.outputs.conan-key }}" | tee -a "$GITHUB_OUTPUT"
+            echo "conan-home=${{ needs.build-deps-windows.outputs.conan-home }}" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          exit 1

--- a/.github/workflows/fuzzy-testing.yml
+++ b/.github/workflows/fuzzy-testing.yml
@@ -156,7 +156,7 @@ jobs:
           conan remove --confirm "*"
 
       - name: Build and install
-        run: pip install --verbose .
+        run: pip install --verbose '.[all]'
 
       - name: Clean Conan cache (post-build)
         if: steps.cache-conan.outputs.cache-hit != 'true'

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -85,7 +85,7 @@ jobs:
           echo 'CXX=clang++' >> $GITHUB_ENV
 
       - name: Build and install
-        run: pip install --verbose '.[test]'
+        run: pip install --verbose '.[all,test]'
 
       - name: Save Conan cache
         uses: actions/cache/save@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ optional-dependencies.all = [
 ]
 
 optional-dependencies.test = [
-  "pytest>=8.0"
+  "hictkpy[all]",
+  "pytest>=8.0",
 ]
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@
 [build-system]
 requires = [
   "conan>=2.0.5",
-  "nanobind==2.2.0", # This is required in order to run stubgen
+  "nanobind>=2", # This is required in order to run stubgen
   "numpy",
-  "pandas>=2.1.0,!=2.2.0",
-  "pyarrow==17.0.0",
+  "pandas>=2.1,!=2.2.0",
+  "pyarrow>=14",
   "scikit-build-core>=0.10",
   "scipy",
   "typing_extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,7 @@ optional-dependencies.scipy = [
 ]
 
 optional-dependencies.all = [
-  "hictkpy[pandas]",
-  "hictkpy[scipy]",
+  "hictkpy[pandas,scipy]",
 ]
 
 optional-dependencies.test = [
@@ -55,8 +54,7 @@ optional-dependencies.test = [
 ]
 
 optional-dependencies.dev = [
-  "hictkpy[all]",
-  "hictkpy[test]",
+  "hictkpy[all,test]",
   "black>=24.10",
   "clang-format>=19.1",
   "isort>=5.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,20 @@ classifiers = [
 
 dependencies = [
   "numpy",
-  "pandas>=2.1.0,!=2.2.0",
   "pyarrow>=14",
+]
+
+optional-dependencies.pandas = [
+  "pandas>=2.1.0,!=2.2.0",
+]
+
+optional-dependencies.scipy = [
   "scipy",
+]
+
+optional-dependencies.all = [
+  "hictkpy[pandas]",
+  "hictkpy[scipy]",
 ]
 
 optional-dependencies.test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,15 @@ optional-dependencies.test = [
   "pytest>=8.0",
 ]
 
+optional-dependencies.dev = [
+  "hictkpy[all]",
+  "hictkpy[test]",
+  "black>=24.10",
+  "clang-format>=19.1",
+  "isort>=5.13",
+  "gersemi>=0.15",
+]
+
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.include = ["src/_version.py"]

--- a/src/hictkpy.cpp
+++ b/src/hictkpy.cpp
@@ -25,10 +25,6 @@ NB_MODULE(_hictkpy, m) {
     throw std::runtime_error("failed to initialize pyarrow runtime");
   }
 
-  [[maybe_unused]] auto np = nb::module_::import_("numpy");
-  [[maybe_unused]] auto pd = nb::module_::import_("pandas");
-  [[maybe_unused]] auto ss = nb::module_::import_("scipy.sparse");
-
   m.attr("__hictk_version__") = hictk::config::version::str();
 
   m.doc() = "Blazing fast toolkit to work with .hic and .cool files.";

--- a/src/include/hictkpy/bin_table.hpp
+++ b/src/include/hictkpy/bin_table.hpp
@@ -18,7 +18,7 @@ namespace hictkpy {
 
 template <typename File>
 inline nanobind::object get_bins_from_file(const File &f) {
-  auto pd = nanobind::module_::import_("pandas");
+  auto pd = import_module_checked("pandas");
 
   Dynamic1DA<std::int32_t> chrom_ids{};
   Dynamic1DA<std::int32_t> starts{};

--- a/src/include/hictkpy/nanobind.hpp
+++ b/src/include/hictkpy/nanobind.hpp
@@ -27,3 +27,16 @@ HICTKPY_DISABLE_WARNING_USELESS_CAST
 #include <nanobind/stl/vector.h>
 HICTKPY_DISABLE_WARNING_POP
 // clang-format on
+
+#include <string>
+
+inline nanobind::module_ import_module_checked(const std::string& module_name) {
+  try {
+    return nanobind::module_::import_(module_name.c_str());
+  } catch (nanobind::python_error& e) {
+    // NOLINTNEXTLINE(*-pro-type-vararg)
+    nanobind::raise_from(e, PyExc_ModuleNotFoundError,
+                         "To enable %s support, please install %s with: pip install 'hictkpy[%s]'",
+                         module_name.c_str(), module_name.c_str(), module_name.c_str());
+  }
+}

--- a/src/pixel_selector.cpp
+++ b/src/pixel_selector.cpp
@@ -206,6 +206,7 @@ nb::object PixelSelector::to_arrow(std::string_view span) const {
 }
 
 nb::object PixelSelector::to_pandas(std::string_view span) const {
+  import_module_checked("pandas");
   return to_arrow(span).attr("to_pandas")();
 }
 
@@ -222,6 +223,7 @@ template <typename N, typename PixelSelector>
 }
 
 nb::object PixelSelector::to_csr(std::string_view span) const {
+  import_module_checked("scipy");
   const auto query_span = parse_span(span);
 
   return std::visit(
@@ -237,6 +239,7 @@ nb::object PixelSelector::to_csr(std::string_view span) const {
 }
 
 nb::object PixelSelector::to_coo(std::string_view span) const {
+  import_module_checked("scipy");
   return to_csr(span).attr("tocoo")(false);
 }
 

--- a/test/test_fetch_dense.py
+++ b/test/test_fetch_dense.py
@@ -5,8 +5,8 @@
 import os
 
 import numpy as np
+import numpy.typing as npt
 import pytest
-from scipy.linalg import issymmetric
 
 import hictkpy
 
@@ -19,6 +19,16 @@ pytestmark = pytest.mark.parametrize(
         (os.path.join(testdir, "data", "hic_test_file.hic"), 100_000),
     ],
 )
+
+
+def issymmetric(m: npt.NDArray) -> bool:
+    assert m.ndim == 2
+    if m.size == 0:
+        return True
+    if m.shape[0] != m.shape[1]:
+        return False
+
+    return np.allclose(m, m.T, atol=0.0, rtol=0.0)
 
 
 class TestClass:

--- a/test/test_fetch_df.py
+++ b/test/test_fetch_df.py
@@ -20,6 +20,16 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+def pandas_avail() -> bool:
+    try:
+        import pandas
+    except ModuleNotFoundError:
+        return False
+
+    return True
+
+
+@pytest.mark.skipif(not pandas_avail(), reason="pandas is not available")
 class TestClass:
     def test_genome_wide(self, file, resolution):
         f = hictkpy.File(file, resolution)

--- a/test/test_fetch_sparse.py
+++ b/test/test_fetch_sparse.py
@@ -20,6 +20,16 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+def scipy_avail() -> bool:
+    try:
+        import scipy
+    except ModuleNotFoundError:
+        return False
+
+    return True
+
+
+@pytest.mark.skipif(not scipy_avail(), reason="scipy is not available")
 class TestClass:
     def test_genome_wide(self, file, resolution):
         f = hictkpy.File(file, resolution)

--- a/test/test_file_accessors.py
+++ b/test/test_file_accessors.py
@@ -20,13 +20,25 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+def pandas_avail() -> bool:
+    try:
+        import pandas
+    except ModuleNotFoundError:
+        return False
+
+    return True
+
+
 class TestClass:
+    @pytest.mark.skipif(not pandas_avail(), reason="pandas is not available")
     def test_attributes(self, file, resolution):
         f = hictkpy.File(file, resolution)
         assert f.resolution() == 100_000
+        assert f.nchroms() == 8
         assert f.nbins() == 1380
 
         assert "chr2L" in f.chromosomes()
+
         assert len(f.bins()) == 1380
         assert len(f.chromosomes()) == 8
 
@@ -47,4 +59,4 @@ class TestClass:
 
         name = "weight" if f.is_cooler() else "ICE"
         weights = f.weights(name)
-        assert len(weights) == len(f.bins())
+        assert len(weights) == f.nbins()

--- a/test/test_file_accessors.py
+++ b/test/test_file_accessors.py
@@ -34,7 +34,7 @@ class TestClass:
     def test_attributes(self, file, resolution):
         f = hictkpy.File(file, resolution)
         assert f.resolution() == 100_000
-        assert f.nchroms() == 8
+        # assert f.nchroms() == 8  # TODO enable after merging https://github.com/paulsengroup/hictk/pull/294
         assert f.nbins() == 1380
 
         assert "chr2L" in f.chromosomes()

--- a/test/test_file_creation_cool.py
+++ b/test/test_file_creation_cool.py
@@ -21,6 +21,16 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+def pandas_avail() -> bool:
+    try:
+        import pandas
+    except ModuleNotFoundError:
+        return False
+
+    return True
+
+
+@pytest.mark.skipif(not pandas_avail(), reason="pandas is not available")
 class TestClass:
     def test_file_creation_thin_pixel(self, file, resolution, tmpdir):
         f = hictkpy.File(file, resolution)

--- a/test/test_file_creation_hic.py
+++ b/test/test_file_creation_hic.py
@@ -21,6 +21,16 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+def pandas_avail() -> bool:
+    try:
+        import pandas
+    except ModuleNotFoundError:
+        return False
+
+    return True
+
+
+@pytest.mark.skipif(not pandas_avail(), reason="pandas is not available")
 class TestClass:
     def test_file_creation_thin_pixel(self, file, resolution, tmpdir):
         f = hictkpy.File(file, resolution)


### PR DESCRIPTION
Closes https://github.com/paulsengroup/hictkpy/issues/77.

Attempting to call functions depending on unavailable third-party dependencies will result in errors like

```pycon
>>> import hictkpy
>>> f = hictkpy.File("test/data/cooler_test_file.mcool", 100_000)
>>> f.fetch().to_df()
ModuleNotFoundError: No module named 'pandas'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: To enable pandas support, please install pandas with: pip install 'hictkpy[pandas]'
>>>
```