### PR TITLE
Fix PixelSelector::get_coord*()

### DIFF
--- a/src/include/hictkpy/pixel_selector.hpp
+++ b/src/include/hictkpy/pixel_selector.hpp
@@ -48,11 +48,10 @@ struct PixelSelector {
 
   [[nodiscard]] std::string repr() const;
 
-  using PixelCoordTuple =
-      std::tuple<std::string, std::int32_t, std::int32_t, std::string, std::int32_t, std::int32_t>;
+  using GenomicCoordTuple = std::tuple<std::string, std::int64_t, std::int64_t>;
 
-  [[nodiscard]] auto get_coord1() const -> PixelCoordTuple;
-  [[nodiscard]] auto get_coord2() const -> PixelCoordTuple;
+  [[nodiscard]] auto get_coord1() const -> GenomicCoordTuple;
+  [[nodiscard]] auto get_coord2() const -> GenomicCoordTuple;
 
   [[nodiscard]] nanobind::iterator make_iterable() const;
   [[nodiscard]] nanobind::object to_arrow(std::string_view span = "upper_triangle") const;

--- a/src/pixel_selector.cpp
+++ b/src/pixel_selector.cpp
@@ -66,7 +66,9 @@ std::string PixelSelector::repr() const {
                        count_type_to_str(pixel_count));
   }
 
-  return fmt::format(FMT_STRING("PixelSelector({}, {}; {}; {})"), coord1(), coord2(),
+  return fmt::format(FMT_STRING("PixelSelector({}:{}-{}; {}:{}-{}; {}; {})"),
+                     coord1().bin1.chrom().name(), coord1().bin1.start(), coord1().bin2.end(),
+                     coord2().bin1.chrom().name(), coord2().bin1.start(), coord2().bin2.end(),
                      pixel_format == PixelFormat::COO ? "COO" : "BG2",
                      count_type_to_str(pixel_count));
 }
@@ -105,16 +107,24 @@ const hictk::BinTable& PixelSelector::bins() const noexcept {
   return std::visit([](const auto& s) -> const hictk::BinTable& { return s->bins(); }, selector);
 }
 
-auto PixelSelector::get_coord1() const -> PixelCoordTuple {
-  const auto c = coord1();
-  return PixelCoordTuple{std::make_tuple(c.bin1.chrom().name(), c.bin1.start(), c.bin1.end(),
-                                         c.bin2.chrom().name(), c.bin2.start(), c.bin2.end())};
+[[nodiscard]] static PixelSelector::GenomicCoordTuple coords_to_tuple(
+    const hictk::PixelCoordinates& coords, const hictk::BinTable& bins) {
+  if (!coords) {
+    return {"ALL", 0, static_cast<std::int64_t>(bins.size())};
+  }
+
+  assert(coords.bin1.chrom() == coords.bin2.chrom());
+
+  return {std::string{coords.bin1.chrom().name()}, static_cast<std::int64_t>(coords.bin1.start()),
+          static_cast<std::int64_t>(coords.bin2.end())};
 }
 
-auto PixelSelector::get_coord2() const -> PixelCoordTuple {
-  const auto c = coord2();
-  return PixelCoordTuple{std::make_tuple(c.bin1.chrom().name(), c.bin1.start(), c.bin1.end(),
-                                         c.bin2.chrom().name(), c.bin2.start(), c.bin2.end())};
+auto PixelSelector::get_coord1() const -> GenomicCoordTuple {
+  return coords_to_tuple(coord1(), bins());
+}
+
+auto PixelSelector::get_coord2() const -> GenomicCoordTuple {
+  return coords_to_tuple(coord2(), bins());
 }
 
 template <typename N, typename PixelSelector>

--- a/test/test_pixel_selector_accessors.py
+++ b/test/test_pixel_selector_accessors.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2023 Roberto Rossini <roberros@uio.no>
+#
+# SPDX-License-Identifier: MIT
+
+import pathlib
+
+import pytest
+
+import hictkpy
+
+from .helpers import numpy_avail
+
+testdir = pathlib.Path(__file__).resolve().parent
+
+pytestmark = pytest.mark.parametrize(
+    "file,resolution",
+    [
+        (testdir / "data" / "cooler_test_file.mcool", 100_000),
+        (testdir / "data" / "hic_test_file.hic", 100_000),
+    ],
+)
+
+
+@pytest.mark.skipif(not numpy_avail(), reason="numpy is not available")
+class TestClass:
+    def test_repr(self, file, resolution):
+        f = hictkpy.File(file, resolution)
+
+        sel = f.fetch()
+        assert str(sel) == "PixelSelector(ALL; COO; int32)"
+
+        sel = f.fetch(join=True)
+        assert str(sel) == "PixelSelector(ALL; BG2; int32)"
+
+        sel = f.fetch(count_type="float")
+        assert str(sel) == "PixelSelector(ALL; COO; float64)"
+
+        sel = f.fetch("chr2L:0-10,000,000", "chr2L:5,000,000-20,000,000")
+        assert str(sel) == "PixelSelector(chr2L:0-10000000; chr2L:5000000-20000000; COO; int32)"
+
+    def test_coords(self, file, resolution):
+        f = hictkpy.File(file, resolution)
+
+        sel = f.fetch()
+        assert sel.coord1() == ("ALL", 0, len(f.bins()))
+        assert sel.coord1() == sel.coord2()
+
+        sel = f.fetch("chr2L:0-10,000,000")
+        assert sel.coord1() == ("chr2L", 0, 10_000_000)
+        assert sel.coord1() == sel.coord2()
+
+        sel = f.fetch("chr2L:0-10,000,000", "chr2L:5,000,000-20,000,000")
+        assert sel.coord1() == ("chr2L", 0, 10_000_000)
+        assert sel.coord2() == ("chr2L", 5_000_000, 20_000_000)


### PR DESCRIPTION
Each method should return a triplet, not the full PixelSelector coordinates.