### PR TITLE
Fix datarace in logging code

### DIFF
--- a/src/cooler_file_writer.cpp
+++ b/src/cooler_file_writer.cpp
@@ -213,7 +213,8 @@ void CoolerFileWriter::bind(nb::module_ &m) {
              "either with columns=[bin1_id, bin2_id, count] or with columns=[chrom1, start1, end1, "
              "chrom2, start2, end2, count].");
   // NOLINTBEGIN(*-avoid-magic-numbers)
-  writer.def("finalize", &hictkpy::CoolerFileWriter::finalize, nb::arg("log_lvl") = "WARN",
+  writer.def("finalize", &hictkpy::CoolerFileWriter::finalize,
+             nb::call_guard<nb::gil_scoped_release>(), nb::arg("log_lvl") = "WARN",
              nb::arg("chunk_size") = 500'000, nb::arg("update_frequency") = 10'000'000,
              "Write interactions to file.", nb::rv_policy::move);
   // NOLINTEND(*-avoid-magic-numbers)

--- a/src/cooler_file_writer.cpp
+++ b/src/cooler_file_writer.cpp
@@ -16,6 +16,7 @@
 #include <hictk/reference.hpp>
 #include <hictk/tmpdir.hpp>
 #include <hictk/type_traits.hpp>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -86,11 +87,12 @@ void CoolerFileWriter::add_pixels(const nb::object &df) {
         "caught attempt to add_pixels to a .cool file that has already been finalized!");
   }
 
-  const auto coo_format = nb::cast<bool>(df.attr("columns").attr("__contains__")("bin1_id"));
-
   const auto cell_id = fmt::to_string(_w->cells().size());
   auto attrs = hictk::cooler::Attributes::init(_w->resolution());
   attrs.assembly = _w->attributes().assembly;
+
+  auto lck = std::make_optional<nb::gil_scoped_acquire>();
+  const auto coo_format = nb::cast<bool>(df.attr("columns").attr("__contains__")("bin1_id"));
 
   const auto dtype = df.attr("__getitem__")("count").attr("dtype");
   const auto dtype_str = nb::cast<std::string>(dtype.attr("__str__")());
@@ -101,6 +103,7 @@ void CoolerFileWriter::add_pixels(const nb::object &df) {
         using N = hictk::remove_cvref_t<decltype(n)>;
         const auto pixels = coo_format ? coo_df_to_thin_pixels<N>(df, true)
                                        : bg2_df_to_thin_pixels<N>(_w->bins(), df, true);
+        lck.reset();
 
         auto clr = _w->create_cell<N>(cell_id, std::move(attrs),
                                       hictk::cooler::DEFAULT_HDF5_CACHE_SIZE * 4, 1);
@@ -208,6 +211,7 @@ void CoolerFileWriter::bind(nb::module_ &m) {
              nb::sig("def bins(self) -> hictkpy.BinTable"), nb::rv_policy::move);
 
   writer.def("add_pixels", &hictkpy::CoolerFileWriter::add_pixels,
+             nb::call_guard<nb::gil_scoped_release>(),
              nb::sig("def add_pixels(self, pixels: pandas.DataFrame)"), nb::arg("pixels"),
              "Add pixels from a pandas DataFrame containing pixels in COO or BG2 format (i.e. "
              "either with columns=[bin1_id, bin2_id, count] or with columns=[chrom1, start1, end1, "

--- a/src/hic_file_writer.cpp
+++ b/src/hic_file_writer.cpp
@@ -196,7 +196,8 @@ void HiCFileWriter::bind(nb::module_ &m) {
              "Add pixels from a pandas DataFrame containing pixels in COO or BG2 format (i.e. "
              "either with columns=[bin1_id, bin2_id, count] or with columns=[chrom1, start1, end1, "
              "chrom2, start2, end2, count].");
-  writer.def("finalize", &hictkpy::HiCFileWriter::finalize, nb::arg("log_lvl") = "WARN",
+  writer.def("finalize", &hictkpy::HiCFileWriter::finalize,
+             nb::call_guard<nb::gil_scoped_release>(), nb::arg("log_lvl") = "WARN",
              "Write interactions to file.", nb::rv_policy::move);
 }
 

--- a/src/hictkpy.cpp
+++ b/src/hictkpy.cpp
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 #include <hictk/version.hpp>
-#include <stdexcept>
 
 #include "hictkpy/bin_table.hpp"
 #include "hictkpy/cooler_file_writer.hpp"

--- a/src/include/hictkpy/logger.hpp
+++ b/src/include/hictkpy/logger.hpp
@@ -9,24 +9,20 @@
 #include <memory>
 #include <string_view>
 
-#include "hictkpy/nanobind.hpp"
-
 namespace hictkpy {
 
 class Logger {
-  nanobind::object _py_logger{};
   std::shared_ptr<spdlog::logger> _logger{};
 
  public:
-  explicit Logger(spdlog::level::level_enum level_ = spdlog::level::warn);
-  explicit Logger(std::string_view level_);
+  explicit Logger(spdlog::level::level_enum level = spdlog::level::warn);
+  explicit Logger(std::string_view level);
 
   [[nodiscard]] std::shared_ptr<spdlog::logger> get_logger();
 
  private:
-  [[nodiscard]] static nanobind::object init_py_logger();
   [[nodiscard]] static std::shared_ptr<spdlog::logger> init_cpp_logger(
-      spdlog::level::level_enum level_, nanobind::object py_logger);
+      spdlog::level::level_enum level);
 };
 
 }  // namespace hictkpy


### PR DESCRIPTION
The datarace could occur when spdlog was is called from any thread other than the main thread.