### PR TITLE
Bring back compatibility with recent versions of MSVC

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, macos-latest, ubuntu-latest]
+        os: [windows-2022, macos-latest, ubuntu-latest]
         python-version: ["3.9", "3.13"]
 
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,14 +159,4 @@ if(WIN32)
   )
 endif()
 
-if(MSVC)
-  if(MSVC_VERSION GREATER 1939)
-    message(
-      FATAL_ERROR
-      "MSVC versions after 19.39.33523.0 (and at least up to 19.42.34321.1) are known to produce broken hictkpy wheels. Please try again using MSVC 19.39.33523.0 (Visual Studio 17.9) or older."
-    )
-  endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-endif()
-
 add_subdirectory(src)


### PR DESCRIPTION
Supersedes https://github.com/paulsengroup/hictkpy/pull/97.
Closes https://github.com/paulsengroup/hictkpy/issues/79.