### PR TITLE
[ci]: use clang to build wheels on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,10 @@ before-build = [
   "rm -rf '{project}/build'",
 ]
 
+[tool.cibuildwheel.linux]
+before-all = "dnf install -y clang"
+environment = { "CC"="clang", "CXX"="clang++" }
+
 # We are using static linking, thus repairing wheels should not be necessary.
 # Exception being when building portable Linux wheels.
 # See https://github.com/scikit-build/scikit-build-core/pull/698#issuecomment-2082991257

--- a/src/pixel_aggregator_impl.hpp
+++ b/src/pixel_aggregator_impl.hpp
@@ -338,7 +338,7 @@ inline void PixelAggregator::process_all_remaining_pixels(Accumulator<N>& accumu
                                                           It&& last) {
   assert(_compute_count);
   // This is just a workaround to allow wrapping drop_value and early_return with HICTKPY_UNLIKELY
-  auto drop_pixel = [this](const auto n) noexcept {
+  auto drop_pixel = [](const auto n) noexcept {
     return internal::drop_value<keep_nans, keep_infs>(n);
   };
 
@@ -566,7 +566,7 @@ inline N PixelAggregator::extract_max(const Accumulator<N>& accumulator) const {
       return std::numeric_limits<N>::infinity();
     }
     if (!_finite_found && _neg_inf_found) {
-      return !std::numeric_limits<N>::infinity();
+      return -std::numeric_limits<N>::infinity();
     }
   }
   return boost::accumulators::max(accumulator);


### PR DESCRIPTION
This is mostly due to performance reasons: hictk is significantly faster when compiled with modern versions of clang.