### PR TITLE
[fix]: suppress warnings about leaked refs to nanobind objects

### DIFF
--- a/src/hictkpy.cpp
+++ b/src/hictkpy.cpp
@@ -30,6 +30,8 @@ namespace hictkpy {
 }
 
 NB_MODULE(_hictkpy, m) {
+  // Leaks appear to only occur when the interpreter shuts down abruptly
+  nb::set_leak_warnings(false);
   [[maybe_unused]] const auto logger = init_logger();
 
   m.attr("__hictk_version__") = hictk::config::version::str();


### PR DESCRIPTION
This should be ok, as I've only observed warnings about leaks when the interpreter shuts down abruptly.
See https://nanobind.readthedocs.io/en/latest/refleaks.html for more details.