### PR TITLE
[enhancement]: make mapping numeric Python types to C++ types more robust

### DIFF
--- a/src/cooler_file_writer.cpp
+++ b/src/cooler_file_writer.cpp
@@ -96,7 +96,7 @@ void CoolerFileWriter::add_pixels(const nb::object &df, bool sorted, bool valida
 
   const auto dtype = df.attr("__getitem__")("count").attr("dtype");
   const auto dtype_str = nb::cast<std::string>(dtype.attr("__str__")());
-  const auto var = map_py_type_to_cpp_type(dtype_str);
+  const auto var = map_py_numeric_to_cpp_type(dtype_str);
 
   std::visit(
       [&](const auto &n) {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -167,7 +167,7 @@ static hictkpy::PixelSelector fetch(const hictk::File &f, std::optional<std::str
 
   return fetch_impl(
       f, std::move(range1), std::move(range2), normalization_method,
-      std::visit([](const auto &ct) { return map_py_type_to_cpp_type(ct); }, count_type), join,
+      std::visit([](const auto &ct) { return map_py_numeric_to_cpp_type(ct); }, count_type), join,
       query_type == "UCSC" ? hictk::GenomicInterval::Type::UCSC : hictk::GenomicInterval::Type::BED,
       diagonal_band_width);
 }

--- a/src/include/hictkpy/type.hpp
+++ b/src/include/hictkpy/type.hpp
@@ -69,8 +69,8 @@ template <typename T>
 #endif
 }
 
-[[nodiscard]] hictk::internal::NumericVariant map_py_type_to_cpp_type(
+[[nodiscard]] hictk::internal::NumericVariant map_py_numeric_to_cpp_type(
     const nanobind::type_object& dtype);
-[[nodiscard]] hictk::internal::NumericVariant map_py_type_to_cpp_type(std::string_view dtype);
+[[nodiscard]] hictk::internal::NumericVariant map_py_numeric_to_cpp_type(std::string_view dtype);
 
 }  // namespace hictkpy

--- a/src/pixel_selector.cpp
+++ b/src/pixel_selector.cpp
@@ -88,17 +88,17 @@ PixelSelector::PixelSelector(std::shared_ptr<const hictk::hic::PixelSelectorAll>
 PixelSelector::PixelSelector(std::shared_ptr<const hictk::cooler::PixelSelector> sel_,
                              const nb::type_object& type, bool join,
                              std::optional<std::int64_t> diagonal_band_width)
-    : PixelSelector(std::move(sel_), map_py_type_to_cpp_type(type), join, diagonal_band_width) {}
+    : PixelSelector(std::move(sel_), map_py_numeric_to_cpp_type(type), join, diagonal_band_width) {}
 
 PixelSelector::PixelSelector(std::shared_ptr<const hictk::hic::PixelSelector> sel_,
                              const nb::type_object& type, bool join,
                              std::optional<std::int64_t> diagonal_band_width)
-    : PixelSelector(std::move(sel_), map_py_type_to_cpp_type(type), join, diagonal_band_width) {}
+    : PixelSelector(std::move(sel_), map_py_numeric_to_cpp_type(type), join, diagonal_band_width) {}
 
 PixelSelector::PixelSelector(std::shared_ptr<const hictk::hic::PixelSelectorAll> sel_,
                              const nb::type_object& type, bool join,
                              std::optional<std::int64_t> diagonal_band_width)
-    : PixelSelector(std::move(sel_), map_py_type_to_cpp_type(type), join, diagonal_band_width) {}
+    : PixelSelector(std::move(sel_), map_py_numeric_to_cpp_type(type), join, diagonal_band_width) {}
 
 std::string PixelSelector::repr() const {
   if (!coord1()) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -57,7 +57,7 @@ namespace nb = nanobind;
   return nb::cast<bool>(np.attr("issubdtype")(dtype1, np.attr(dtype2)));
 }
 
-hictk::internal::NumericVariant map_py_type_to_cpp_type(const nb::type_object& dtype) {
+hictk::internal::NumericVariant map_py_numeric_to_cpp_type(const nb::type_object& dtype) {
   const auto np = import_module_checked("numpy");
   if (!issubdtype(np, dtype, "number")) {
     throw_exception(dtype, "Not a subdtype of numpy.number.");
@@ -99,7 +99,7 @@ hictk::internal::NumericVariant map_py_type_to_cpp_type(const nb::type_object& d
   throw_exception(dtype);
 }
 
-hictk::internal::NumericVariant map_py_type_to_cpp_type(std::string_view dtype) {
+hictk::internal::NumericVariant map_py_numeric_to_cpp_type(std::string_view dtype) {
   // NOLINTBEGIN(*-avoid-magic-numbers)
   static_assert(sizeof(unsigned) == 4);
   static_assert(sizeof(int) == 4);
@@ -109,7 +109,7 @@ hictk::internal::NumericVariant map_py_type_to_cpp_type(std::string_view dtype) 
 
   if (const auto pos = dtype.rfind('.'); pos != std::string_view::npos) {
     try {
-      return map_py_type_to_cpp_type(dtype.substr(pos + 1));
+      return map_py_numeric_to_cpp_type(dtype.substr(pos + 1));
     } catch (const std::exception& e) {
       throw_exception(dtype, e.what());
     }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -52,21 +52,6 @@ namespace nb = nanobind;
   throw_exception(dtype_object_to_str(dtype), msg);
 }
 
-template <std::size_t I>
-[[nodiscard]] static std::optional<hictk::internal::NumericVariant> map_py_type_to_cpp_type_helper(
-    const nb::object& x) {
-  using Var = hictk::internal::NumericVariant;
-  if constexpr (I < std::variant_size_v<Var>) {
-    using N = std::variant_alternative_t<I, Var>;
-    if (nb::isinstance<N>(x)) {
-      return N{};
-    }
-    return map_py_type_to_cpp_type_helper<I + 1>(x);
-  }
-
-  return {};
-}
-
 [[nodiscard]] static bool issubdtype(const nb::module_& np, const nb::type_object& dtype1,
                                      const char* dtype2) {
   return nb::cast<bool>(np.attr("issubdtype")(dtype1, np.attr(dtype2)));

--- a/test/test_file_accessors.py
+++ b/test/test_file_accessors.py
@@ -71,9 +71,48 @@ class TestClass:
 
         f = hictkpy.File(file, resolution)
 
-        assert f.fetch().dtype() is np.int32
-        assert f.fetch(count_type=float).dtype() is np.float64
-        assert f.fetch(count_type=np.int8).dtype() is np.int8
+        valid_types = {
+            int: np.int64,
+            float: np.float64,
+            np.uint8: np.uint8,
+            np.uint16: np.uint16,
+            np.uint32: np.uint32,
+            np.uint64: np.uint64,
+            np.int8: np.int8,
+            np.int16: np.int16,
+            np.int32: np.int32,
+            np.int64: np.int64,
+            "int": np.int32,
+            "uint": np.uint32,
+            "float": np.float64,
+            "uint8": np.uint8,
+            "uint16": np.uint16,
+            "uint32": np.uint32,
+            "uint64": np.uint64,
+            "int8": np.int8,
+            "int16": np.int16,
+            "int32": np.int32,
+            "int64": np.int64,
+        }
 
-        with pytest.raises(TypeError):
-            f.fetch(count_type=str)
+        invalid_types = [
+            object,
+            bool,
+            str,
+            np.array,
+            np.bool_,
+            np.float16,
+            np.float128,
+            np.complex64,
+            "str",
+            "foobar",
+        ]
+
+        assert f.fetch().dtype() is np.int32
+
+        for t1, t2 in valid_types.items():
+            assert f.fetch(count_type=t1).dtype() is t2
+
+        for t in invalid_types:
+            with pytest.raises(TypeError):
+                f.fetch(count_type=t)

--- a/test/test_file_accessors.py
+++ b/test/test_file_accessors.py
@@ -105,11 +105,15 @@ class TestClass:
                 np.array,
                 np.bool_,
                 np.float16,
-                np.float128,
                 np.complex64,
                 "str",
                 "foobar",
             ]
+
+            try:
+                invalid_types.append(np.float128)
+            except:  # noqa
+                pass
 
         assert f.fetch().dtype() is np.int32
 

--- a/test/test_file_accessors.py
+++ b/test/test_file_accessors.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import pathlib
+import warnings
 
 import pytest
 
@@ -95,18 +96,20 @@ class TestClass:
             "int64": np.int64,
         }
 
-        invalid_types = [
-            object,
-            bool,
-            str,
-            np.array,
-            np.bool_,
-            np.float16,
-            np.float128,
-            np.complex64,
-            "str",
-            "foobar",
-        ]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            invalid_types = [
+                object,
+                bool,
+                str,
+                np.array,
+                np.bool_,
+                np.float16,
+                np.float128,
+                np.complex64,
+                "str",
+                "foobar",
+            ]
 
         assert f.fetch().dtype() is np.int32
 


### PR DESCRIPTION
For some odd resons, for certain combinations of Python versions/distribution and platforms, calling something like

```python3
f = hictkpy.File(...)
with pytest.raises(TypeError):
    f.fetch(count_type=str)
```

could lead to UnicodeDecodeError exceptions with the previous logic. This likely occurred when falling back to parsing the string representation of a type when inferring the C++ type from the Python type.

This does not occur in our CI runs or dev machine, but it seems to occur when using conda's Python 3.12 distribution on Linux (both x86_64 and aarch64).

In case someone runs into this problem with valid numeric types (e.g. `int` or `np.int64`), the current workaround for this issue is to pass the type as a string (without the `np` prefix).